### PR TITLE
修正中文语言标识

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -9,17 +9,17 @@ class Extension extends BaseExtension
     public function listen(Dispatcher $events)
     {
         $events->listen(RegisterLocales::class, function (RegisterLocales $event) {
-            $event->manager->addLocale('zh-CN', '中文简体');
-            $event->addTranslations('zh-CN', __DIR__.'/../locale/core.yml');
-            $event->manager->addJsFile('zh-CN', __DIR__.'/../locale/core.js');
-            $event->manager->addConfig('zh-CN', __DIR__.'/../locale/core.php');
-            $event->addTranslations('zh-CN', __DIR__.'/../locale/likes.yml');
-            $event->addTranslations('zh-CN', __DIR__.'/../locale/lock.yml');
-            $event->addTranslations('zh-CN', __DIR__.'/../locale/mentions.yml');
-            $event->addTranslations('zh-CN', __DIR__.'/../locale/pusher.yml');
-            $event->addTranslations('zh-CN', __DIR__.'/../locale/sticky.yml');
-            $event->addTranslations('zh-CN', __DIR__.'/../locale/subscriptions.yml');
-            $event->addTranslations('zh-CN', __DIR__.'/../locale/tags.yml');
+            $event->manager->addLocale('zh_CN', '中文简体');
+            $event->addTranslations('zh_CN', __DIR__.'/../locale/core.yml');
+            $event->manager->addJsFile('zh_CN', __DIR__.'/../locale/core.js');
+            $event->manager->addConfig('zh_CN', __DIR__.'/../locale/core.php');
+            $event->addTranslations('zh_CN', __DIR__.'/../locale/likes.yml');
+            $event->addTranslations('zh_CN', __DIR__.'/../locale/lock.yml');
+            $event->addTranslations('zh_CN', __DIR__.'/../locale/mentions.yml');
+            $event->addTranslations('zh_CN', __DIR__.'/../locale/pusher.yml');
+            $event->addTranslations('zh_CN', __DIR__.'/../locale/sticky.yml');
+            $event->addTranslations('zh_CN', __DIR__.'/../locale/subscriptions.yml');
+            $event->addTranslations('zh_CN', __DIR__.'/../locale/tags.yml');
         });
     }
 }


### PR DESCRIPTION
标准的简体中文i18n代码是zh_CN，语言与国家之间是下划线
